### PR TITLE
Homomorphic Subtraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Created by http://gitignore.io
 
+cabal.project.local~
+
 ### OSX ###
 .DS_Store
 .AppleDouble

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cabal-dev
 *.chi
 *.chs.h
 .virthualenv
+dist-newstyle/

--- a/Paillier.cabal
+++ b/Paillier.cabal
@@ -20,11 +20,11 @@ library
  hs-source-dirs: src
  exposed-modules: Crypto.Paillier
  default-language: Haskell2010
- build-depends: base >=4.6 && <4.10, crypto-numbers >= 0.2.2, crypto-random >= 0.0.7
+ build-depends: base >=4.6, crypto-numbers >= 0.2.2, crypto-random >= 0.0.7
 
 executable paillier
   main-is: Main.hs
-  build-depends:       base >=4.6 && <4.10, cmdargs >= 0.10.5, Paillier >= 0.1.0.0
+  build-depends:       base >=4.6, cmdargs >= 0.10.5, Paillier >= 0.1.0.0
   default-language:    Haskell2010
 
 Test-suite test-Paillier
@@ -33,7 +33,7 @@ Test-suite test-Paillier
   main-is: TestMain.hs
   build-depends: QuickCheck >= 2.6, HUnit, test-framework-th, test-framework, 
                 test-framework-quickcheck2,
-                base >=4.6 && <4.10, crypto-numbers >= 0.2.2, crypto-random >= 0.0.7,
+                base >=4.6, crypto-numbers >= 0.2.2, crypto-random >= 0.0.7,
                 Paillier
   default-language: Haskell2010
 

--- a/Paillier.cabal
+++ b/Paillier.cabal
@@ -18,13 +18,15 @@ source-repository this
 
 library
  hs-source-dirs: src
- exposed-modules: Crypto.Paillier
+ exposed-modules: 
+        Crypto.PaillierRealNum
+        Crypto.Paillier
  default-language: Haskell2010
  build-depends: base >=4.6, crypto-numbers >= 0.2.2, crypto-random >= 0.0.7
 
 executable paillier
   main-is: Main.hs
-  build-depends:       base >=4.6, cmdargs >= 0.10.5, Paillier >= 0.1.0.0
+  build-depends:       base >=4.6, cmdargs >= 0.10.5, Paillier
   default-language:    Haskell2010
 
 Test-suite test-Paillier

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,1 @@
+ignore-project: False

--- a/src/Crypto/Paillier.hs
+++ b/src/Crypto/Paillier.hs
@@ -11,6 +11,8 @@ import Crypto.Number.ModArithmetic
 import System.IO
 #endif
 
+
+
 type PlainText = Integer 
 
 type CipherText = Integer
@@ -19,6 +21,7 @@ data PubKey = PubKey{  bits :: Int  -- ^ e.g., 2048
                      , nModulo :: Integer -- ^ n = pq
                      , generator :: Integer -- ^ generator = n+1
                      , nSquare :: Integer -- ^ n^2
+                     , maxInt  :: Integer -- ^ n/3
                     } deriving (Show)
 
 data PrvKey = PrvKey{  lambda :: Integer -- ^ lambda(n) = lcm(p-1, q-1)
@@ -46,7 +49,7 @@ genKey nBits = do
     if isNothing maybeU then
        error "genKey failed." 
     else
-        return (PubKey{bits=nBits, nModulo=modulo, generator=g, nSquare=square}
+        return (PubKey{bits=nBits, nModulo=modulo, generator=g, nSquare=square, maxInt = (modulo `div` 3)}
            ,PrvKey{lambda=phi_n, x=fromJust maybeU})
 
 -- | deterministic version of encryption
@@ -101,4 +104,3 @@ homoSub :: PubKey -> CipherText -> CipherText -> CipherText
 homoSub pubKey c1 c2 = cipherMul pubKey c1 minusc2
   where
     minusc2 = cipherExp pubKey c2 (-1)
-

--- a/src/Crypto/Paillier.hs
+++ b/src/Crypto/Paillier.hs
@@ -96,5 +96,9 @@ cipherMul pubKey c1 c2 = c1*c2 `mod` nSquare pubKey
 cipherExp :: PubKey -> CipherText -> PlainText -> CipherText
 cipherExp pubKey c1 p1 = expSafe c1 p1 (nSquare pubKey)
 
-
+-- | Homomorphic subtraction => c1 - c2, given two ciphertexts c1 and c2
+homoSub :: PubKey -> CipherText -> CipherText -> CipherText
+homoSub pubKey c1 c2 = cipherMul pubKey c1 minusc2
+  where
+    minusc2 = cipherExp pubKey c2 (-1)
 

--- a/src/Crypto/PaillierRealNum.hs
+++ b/src/Crypto/PaillierRealNum.hs
@@ -1,0 +1,89 @@
+module Crypto.PaillierRealNum where
+
+import Crypto.Paillier as P hiding (homoSub)
+
+
+largenum :: Double
+largenum = 2^10
+
+type PT = (Integer, Integer, Integer)
+
+type CT = (CipherText, CipherText, Integer)
+
+e = 0
+
+encodeF :: Double -> PT
+encodeF x = (x1, x2, 0)
+  where
+    (x1, frac) = (floor x, x - fromIntegral (floor x)) :: (Integer, Double)
+    x2 = floor (frac * largenum) :: Integer
+
+decodeF :: PT -> Double
+decodeF (x1, x2, x3) = (x1D + (x2D/largenum)) / (10^x3)
+  where
+    x1D = fromInteger x1 :: Double
+    x2D = fromInteger x2 :: Double
+
+encrypt :: PubKey -> Double -> IO CT
+encrypt pubK z = do
+  let (x1, x2, x3) = encodeF z
+  x1' <- P.encrypt pubK x1
+  x2' <- P.encrypt pubK x2
+  return (x1', x2', x3)
+
+decrypt :: PubKey -> PrvKey -> CT -> Double
+decrypt pubk prvk (ct1, ct2, i) =
+  let (uen1, uen2, x) = (P.decrypt prvk pubk ct1
+                        ,P.decrypt prvk pubk ct2
+                        ,i
+                        )
+   in decodeF $ (dealwithNeg uen1, dealwithNeg uen2, x)
+   where
+     dealwithNeg i = if i >= (maxInt pubk)
+                     then i - (nModulo pubk)
+                     else i
+
+
+homoAdd :: PubKey -> CT -> CT -> CT
+homoAdd pubk (x1, x2, x3) (y1, y2, y3)
+  | x3 == y3  = (cipherMul pubk x1 y1, cipherMul pubk x2 y2, x3)
+  | otherwise = if (xdiff > 0)
+                then ( cipherExp pubk x1 (10^xdiff)
+                     , cipherExp pubk x2 (10^xdiff)
+                     , res3
+                     )
+                else ( cipherExp pubk y1 (10^ydiff)
+                     , cipherExp pubk y2 (10^ydiff)
+                     , res3
+                     )
+  where
+    res3 = max x3 y3
+    xdiff = res3 - x3
+    ydiff = res3 - y3
+
+homoSub :: PubKey -> CT -> CT -> CT
+homoSub pubk x (y1, y2, y3) =
+  homoAdd pubk x (cipherExp pubk y1 (-1), cipherExp pubk y2 (-1), y3)
+
+precision = 6
+
+homoMul :: PubKey -> CT -> Double -> CT
+homoMul pubk (x1, x2, x3) y =
+  (cipherExp pubk x1 yInt, cipherExp pubk x2 yInt, x3 + precision)
+  where
+    yInt = floor (y * 10^precision) :: Integer
+
+
+
+
+foo :: IO ()
+foo = do
+  (pubK, prvK) <- genKey 1024
+  let m1 = -42.3
+  let m2 = -2.8
+  ct1 <- enc pubK m1
+  ct2 <- enc pubK m2
+  print $ dec pubK prvK $ homoMul pubK ct1 (2.8)
+  where
+    enc = Crypto.PaillierRealNum.encrypt
+    dec = Crypto.PaillierRealNum.decrypt


### PR DESCRIPTION
This commit adds a homomorphic subtraction function, such that the user can call 

```
homoSub cipher1 cipher2
```

and get a ciphertext that upon decryption will return the subtraction between the two plaintexts. This could be a useful utility function. 

I have additionally relaxed the upper bound on `base` that was breaking a personal project of mine and I found the library seems to compile fine with newer `base` versions > 4.10